### PR TITLE
Add filament mismatch warnings

### DIFF
--- a/spoolman_service.py
+++ b/spoolman_service.py
@@ -79,17 +79,37 @@ def augmentTrayDataWithSpoolMan(spool_list, tray_data, tray_id):
 
       tray_material = (tray_data.get("tray_type") or "").strip().lower()
       spool_material = (spool["filament"].get("material") or "").strip().lower()
-      material_mismatch = bool(tray_material and spool_material and tray_material != spool_material)
+
+      tray_material_suffix = ""
+      material_mismatch = False
+      if tray_material and spool_material:
+        if tray_material == spool_material:
+          material_mismatch = False
+        elif tray_material.startswith(spool_material):
+          tray_material_suffix = tray_material[len(spool_material):].strip()
+        else:
+          material_mismatch = True
 
       tray_sub_brand = (tray_data.get("tray_sub_brands") or "").strip().lower()
+      tray_sub_brand_normalized = tray_sub_brand
+
+      if tray_sub_brand_normalized and spool_material and tray_sub_brand_normalized.startswith(spool_material):
+        tray_sub_brand_normalized = tray_sub_brand_normalized[len(spool_material):].strip()
+
+      if not tray_sub_brand_normalized and tray_material_suffix:
+        tray_sub_brand_normalized = tray_material_suffix
+
       filament_sub_brand = tray_data["spool_sub_brand"]
 
       if not filament_sub_brand and spool_material == "pla":
         filament_sub_brand = "basic"
 
+      if not tray_sub_brand_normalized and spool_material == "pla":
+        tray_sub_brand_normalized = "basic"
+
       tray_data["spool_sub_brand"] = filament_sub_brand
 
-      sub_brand_mismatch = bool(tray_sub_brand and tray_sub_brand != filament_sub_brand)
+      sub_brand_mismatch = bool(tray_sub_brand_normalized and tray_sub_brand_normalized != filament_sub_brand)
 
       tray_data["mismatch"] = material_mismatch or sub_brand_mismatch
       tray_data["issue"] = tray_data["mismatch"]

--- a/spoolman_service.py
+++ b/spoolman_service.py
@@ -58,6 +58,7 @@ def augmentTrayDataWithSpoolMan(spool_list, tray_data, tray_id):
       tray_data["name"] = spool["filament"]["name"]
       tray_data["vendor"] = spool["filament"]["vendor"]["name"]
       tray_data["spool_material"] = spool["filament"].get("material", "")
+      tray_data["spool_sub_brand"] = (spool["filament"].get("extra", {}).get("type") or "").strip().lower()
       tray_data["remaining_weight"] = spool["remaining_weight"]
 
       if "last_used" in spool:
@@ -81,10 +82,14 @@ def augmentTrayDataWithSpoolMan(spool_list, tray_data, tray_id):
       material_mismatch = bool(tray_material and spool_material and tray_material != spool_material)
 
       tray_sub_brand = (tray_data.get("tray_sub_brands") or "").strip().lower()
-      vendor_name = (spool["filament"].get("vendor", {}).get("name") or "").strip().lower()
-      filament_type = (spool["filament"].get("extra", {}).get("type") or "").strip().lower()
-      brand_matches = {value for value in [vendor_name, filament_type, f"{vendor_name} {filament_type}".strip()] if value}
-      sub_brand_mismatch = bool(tray_sub_brand and (not brand_matches or tray_sub_brand not in brand_matches))
+      filament_sub_brand = tray_data["spool_sub_brand"]
+
+      if not filament_sub_brand and spool_material == "pla":
+        filament_sub_brand = "basic"
+
+      tray_data["spool_sub_brand"] = filament_sub_brand
+
+      sub_brand_mismatch = bool(tray_sub_brand and tray_sub_brand != filament_sub_brand)
 
       tray_data["mismatch"] = material_mismatch or sub_brand_mismatch
       tray_data["issue"] = tray_data["mismatch"]

--- a/spoolman_service.py
+++ b/spoolman_service.py
@@ -51,13 +51,15 @@ def getAMSFromTray(n):
 
 def augmentTrayDataWithSpoolMan(spool_list, tray_data, tray_id):
   tray_data["matched"] = False
+  tray_data["mismatch"] = False
+  tray_data["issue"] = False
   for spool in spool_list:
     if spool.get("extra") and spool["extra"].get("active_tray") and spool["extra"]["active_tray"] == json.dumps(tray_id):
-      #TODO: check for mismatch
       tray_data["name"] = spool["filament"]["name"]
       tray_data["vendor"] = spool["filament"]["vendor"]["name"]
+      tray_data["spool_material"] = spool["filament"].get("material", "")
       tray_data["remaining_weight"] = spool["remaining_weight"]
-      
+
       if "last_used" in spool:
         try:
             dt = datetime.strptime(spool["last_used"], "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=ZoneInfo("UTC"))
@@ -73,14 +75,24 @@ def augmentTrayDataWithSpoolMan(spool_list, tray_data, tray_id):
       if "multi_color_hexes" in spool["filament"]:
         tray_data["tray_color"] = spool["filament"]["multi_color_hexes"]
         tray_data["tray_color_orientation"] = spool["filament"]["multi_color_direction"]
-        
+
+      tray_material = (tray_data.get("tray_type") or "").strip().lower()
+      spool_material = (spool["filament"].get("material") or "").strip().lower()
+      material_mismatch = bool(tray_material and spool_material and tray_material != spool_material)
+
+      tray_sub_brand = (tray_data.get("tray_sub_brands") or "").strip().lower()
+      vendor_name = (spool["filament"].get("vendor", {}).get("name") or "").strip().lower()
+      filament_type = (spool["filament"].get("extra", {}).get("type") or "").strip().lower()
+      brand_matches = {value for value in [vendor_name, filament_type, f"{vendor_name} {filament_type}".strip()] if value}
+      sub_brand_mismatch = bool(tray_sub_brand and (not brand_matches or tray_sub_brand not in brand_matches))
+
+      tray_data["mismatch"] = material_mismatch or sub_brand_mismatch
+      tray_data["issue"] = tray_data["mismatch"]
       tray_data["matched"] = True
       break
 
   if tray_data.get("tray_type") and tray_data["tray_type"] != "" and tray_data["matched"] == False:
     tray_data["issue"] = True
-  else:
-    tray_data["issue"] = False
 
 def spendFilaments(printdata):
   if printdata["ams_mapping"]:

--- a/spoolman_service.py
+++ b/spoolman_service.py
@@ -82,14 +82,14 @@ def augmentTrayDataWithSpoolMan(spool_list, tray_data, tray_id):
       material_mismatch = bool(tray_material and spool_material and tray_material != spool_material)
 
       tray_sub_brand = (tray_data.get("tray_sub_brands") or "").strip().lower()
-      filament_sub_brand = tray_data["spool_sub_brand"]
+      filament_sub_brand =  tray_data["spool_sub_brand"].replace('"', '').strip().lower()
 
-      if not filament_sub_brand and spool_material == "pla":
-        filament_sub_brand = "basic"
+      if tray_sub_brand:
+        filament_sub_brand = spool_material + " " + filament_sub_brand
 
       tray_data["spool_sub_brand"] = filament_sub_brand
 
-      sub_brand_mismatch = bool(tray_sub_brand and tray_sub_brand != filament_sub_brand)
+      sub_brand_mismatch = bool(tray_sub_brand and tray_sub_brand != tray_data["spool_sub_brand"])
 
       tray_data["mismatch"] = material_mismatch or sub_brand_mismatch
       tray_data["issue"] = tray_data["mismatch"]

--- a/spoolman_service.py
+++ b/spoolman_service.py
@@ -73,7 +73,6 @@ def augmentTrayDataWithSpoolMan(spool_list, tray_data, tray_id):
       else:
           tray_data["last_used"] = "-"
           
-<<<<<<< HEAD
       if "multi_color_hexes" in spool["filament"]:
         tray_data["tray_color"] = spool["filament"]["multi_color_hexes"]
         tray_data["tray_color_orientation"] = spool["filament"]["multi_color_direction"]
@@ -99,53 +98,6 @@ def augmentTrayDataWithSpoolMan(spool_list, tray_data, tray_id):
 
   if tray_data.get("tray_type") and tray_data["tray_type"] != "" and tray_data["matched"] == False:
     tray_data["issue"] = True
-=======
-      if "multi_color_hexes" in spool["filament"]:
-        tray_data["tray_color"] = spool["filament"]["multi_color_hexes"]
-        tray_data["tray_color_orientation"] = spool["filament"]["multi_color_direction"]
-
-      tray_material = (tray_data.get("tray_type") or "").strip().lower()
-      spool_material = (spool["filament"].get("material") or "").strip().lower()
-
-      tray_material_suffix = ""
-      material_mismatch = False
-      if tray_material and spool_material:
-        if tray_material == spool_material:
-          material_mismatch = False
-        elif tray_material.startswith(spool_material):
-          tray_material_suffix = tray_material[len(spool_material):].strip()
-        else:
-          material_mismatch = True
-
-      tray_sub_brand = (tray_data.get("tray_sub_brands") or "").strip().lower()
-      tray_sub_brand_normalized = tray_sub_brand
-
-      if tray_sub_brand_normalized and spool_material and tray_sub_brand_normalized.startswith(spool_material):
-        tray_sub_brand_normalized = tray_sub_brand_normalized[len(spool_material):].strip()
-
-      if not tray_sub_brand_normalized and tray_material_suffix:
-        tray_sub_brand_normalized = tray_material_suffix
-
-      filament_sub_brand = tray_data["spool_sub_brand"]
-
-      if not filament_sub_brand and spool_material == "pla":
-        filament_sub_brand = "basic"
-
-      if not tray_sub_brand_normalized and spool_material == "pla":
-        tray_sub_brand_normalized = "basic"
-
-      tray_data["spool_sub_brand"] = filament_sub_brand
-
-      sub_brand_mismatch = bool(tray_sub_brand_normalized and tray_sub_brand_normalized != filament_sub_brand)
-
-      tray_data["mismatch"] = material_mismatch or sub_brand_mismatch
-      tray_data["issue"] = tray_data["mismatch"]
-      tray_data["matched"] = True
-      break
-
-  if tray_data.get("tray_type") and tray_data["tray_type"] != "" and tray_data["matched"] == False:
-    tray_data["issue"] = True
->>>>>>> c7a32b7fb286c0f2e79e581f3ed04a9a563bfcc9
 
 def spendFilaments(printdata):
   if printdata["ams_mapping"]:

--- a/templates/fragments/tray.html
+++ b/templates/fragments/tray.html
@@ -2,7 +2,7 @@
   <!-- Tray ID -->
   <div class="card-header d-flex justify-content-between align-items-center">
     {% if tray_data.issue %}
-    <i class="bi bi-exclamation-circle text-danger me-2"></i>
+    <i class="bi bi-exclamation-triangle-fill text-warning me-2"></i>
     {% endif %}
     {% if not tray_data.tray_type %}
       Empty
@@ -15,6 +15,17 @@
   </div>
 
   <div class="card-body">
+    {% if tray_data.mismatch %}
+      <div class="alert alert-warning d-flex align-items-start py-2 mb-3">
+        <i class="bi bi-exclamation-triangle-fill text-danger me-2 fs-5"></i>
+        <div class="text-start">
+          <div class="fw-semibold">Filament type mismatch</div>
+          <small>
+            AMS reports {{ tray_data.tray_type }}{% if tray_data.tray_sub_brands %} ({{ tray_data.tray_sub_brands }}){% endif %}, but the assigned spool is {{ tray_data.vendor }} {{ tray_data.name }}{% if tray_data.spool_material %} ({{ tray_data.spool_material }}){% endif %}.
+          </small>
+        </div>
+      </div>
+    {% endif %}
     <!-- Typ & Hersteller -->
     <div class="small text-muted text-center mb-2">
       {% if tray_data.tray_type %}

--- a/templates/fragments/tray.html
+++ b/templates/fragments/tray.html
@@ -21,7 +21,7 @@
         <div class="text-start">
           <div class="fw-semibold">Filament type mismatch</div>
           <small>
-            AMS reports {{ tray_data.tray_type }}{% if tray_data.tray_sub_brands %} ({{ tray_data.tray_sub_brands }}){% endif %}, but the assigned spool is {{ tray_data.vendor }} {{ tray_data.name }}{% if tray_data.spool_material %} ({{ tray_data.spool_material }}){% endif %}.
+            AMS reports {{ tray_data.tray_type }}{% if tray_data.tray_sub_brands %} ({{ tray_data.tray_sub_brands }}){% endif %}, but the assigned spool is {{ tray_data.vendor }} {{ tray_data.name }}{% if tray_data.spool_material %} ({{ tray_data.spool_material }}{% if tray_data.spool_sub_brand %}, {{ tray_data.spool_sub_brand }}{% endif %}){% endif %}.
           </small>
         </div>
       </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,18 +1,6 @@
 {% extends 'base.html' %}
 
 {% block content %}
-{% if issue %}
-<div class="card border-warning shadow-sm mb-4">
-  <div class="card-header bg-warning text-dark fw-bold">
-    Warning
-  </div>
-  <div class="card-body">
-    <h5 class="card-title">AMS filament type does not match the assigned spool</h5>
-    <p class="card-text">Fix the issue by clicking "Fix this tray" on any tray marked with <i class="bi bi-exclamation-triangle-fill text-danger me-2"></i> to reconcile the AMS filament type/brand with the linked SpoolMan spool.</p>
-  </div>
-</div>
-{% endif %}
-
 <!-- AMS and External Spool Row -->
 <div class="row">
   <!-- External Spool -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,8 +7,8 @@
     Warning
   </div>
   <div class="card-body">
-    <h5 class="card-title">There is a mismatch between printer and SpoolMan</h5>
-    <p class="card-text">Fix issue by clicking "Fix this tray" on tray with <i class="bi bi-exclamation-circle text-danger me-2"></i></p>
+    <h5 class="card-title">AMS filament type does not match the assigned spool</h5>
+    <p class="card-text">Fix the issue by clicking "Fix this tray" on any tray marked with <i class="bi bi-exclamation-triangle-fill text-danger me-2"></i> to reconcile the AMS filament type/brand with the linked SpoolMan spool.</p>
   </div>
 </div>
 {% endif %}

--- a/templates/issue.html
+++ b/templates/issue.html
@@ -2,6 +2,15 @@
 
 {% block content %}
 <h1>Solve issue</h1>
+{% if tray_data and tray_data.mismatch %}
+<div class="alert alert-warning d-flex align-items-start" role="alert">
+  <i class="bi bi-exclamation-triangle-fill text-danger me-2 fs-4"></i>
+  <div>
+    <div class="fw-semibold">AMS filament type mismatch detected</div>
+    <div>The AMS reports {{ tray_data.tray_type }}{% if tray_data.tray_sub_brands %} ({{ tray_data.tray_sub_brands }}){% endif %}, but the assigned spool is {{ active_spool.filament.vendor.name }} {{ active_spool.filament.name }}{% if active_spool.filament.material %} ({{ active_spool.filament.material }}){% endif %}. Update the tray or select a matching spool below.</div>
+  </div>
+</div>
+{% endif %}
 {% with current_spool=active_spool %} {% include 'fragments/spool_details.html' %} {% endwith %}
 
 

--- a/templates/issue.html
+++ b/templates/issue.html
@@ -7,7 +7,7 @@
   <i class="bi bi-exclamation-triangle-fill text-danger me-2 fs-4"></i>
   <div>
     <div class="fw-semibold">AMS filament type mismatch detected</div>
-    <div>The AMS reports {{ tray_data.tray_type }}{% if tray_data.tray_sub_brands %} ({{ tray_data.tray_sub_brands }}){% endif %}, but the assigned spool is {{ active_spool.filament.vendor.name }} {{ active_spool.filament.name }}{% if active_spool.filament.material %} ({{ active_spool.filament.material }}){% endif %}. Update the tray or select a matching spool below.</div>
+    <div>The AMS reports {{ tray_data.tray_type }}{% if tray_data.tray_sub_brands %} ({{ tray_data.tray_sub_brands }}){% endif %}, but the assigned spool is {{ active_spool.filament.vendor.name }} {{ active_spool.filament.name }}{% if active_spool.filament.material %} ({{ active_spool.filament.material }}{% if tray_data.spool_sub_brand %}, {{ tray_data.spool_sub_brand }}{% endif %}){% endif %}. Update the tray or select a matching spool below.</div>
   </div>
 </div>
 {% endif %}

--- a/templates/spool_info.html
+++ b/templates/spool_info.html
@@ -1,6 +1,17 @@
 {% extends 'base.html' %}
 
 {% block content %}
+{% if issue %}
+<div class="card border-warning shadow-sm mb-4">
+  <div class="card-header bg-warning text-dark fw-bold">
+    Warning
+  </div>
+  <div class="card-body">
+    <h5 class="card-title">AMS filament type does not match the assigned spool</h5>
+    <p class="card-text">Fix the issue by clicking "Fix this tray" on any tray marked with <i class="bi bi-exclamation-triangle-fill text-danger me-2"></i> to reconcile the AMS filament type/brand with the linked SpoolMan spool.</p>
+  </div>
+</div>
+{% endif %}
 {% include 'fragments/spool_details.html' %}
 
 <h1 class="mb-4">Assign Tray</h1>


### PR DESCRIPTION
## Summary
- detect AMS tray filament type and sub-brand mismatches against linked SpoolMan spools
- surface mismatch flags through home, spool info, and fix flows
- show tray-level warnings to help reconcile AMS filament details with assigned spools

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925d9af9bc48329a05e1c46a6926d29)