### PR TITLE
Add material filtering for print spool selection

### DIFF
--- a/app.py
+++ b/app.py
@@ -403,8 +403,29 @@ def print_select_spool():
       return render_template('error.html', exception="Missing spool ID or print ID.")
 
     spools = fetchSpools()
-        
-    return render_template('print_select_spool.html', spools=spools, ams_slot=ams_slot, print_id=print_id, change_spool=change_spool)
+
+    materials = extract_materials(spools)
+    selected_materials = []
+
+    filament = get_filament_for_slot(print_id, ams_slot)
+
+    try:
+      filament_material = filament["filament_type"] if filament else None
+
+      if filament_material and filament_material in materials:
+        selected_materials.append(filament_material)
+    except Exception:
+      pass
+
+    return render_template(
+      'print_select_spool.html',
+      spools=spools,
+      ams_slot=ams_slot,
+      print_id=print_id,
+      change_spool=change_spool,
+      materials=materials,
+      selected_materials=selected_materials,
+    )
   except Exception as e:
     traceback.print_exc()
     return render_template('error.html', exception=str(e))

--- a/templates/print_select_spool.html
+++ b/templates/print_select_spool.html
@@ -13,5 +13,5 @@
 {% else %}
 <h1 class="mb-4 text-center">Assign spool to print</h1>
 {% endif %}
-{% with action_assign_print=True %}{% include 'fragments/list_spools.html' %}{% endwith %}
+{% with action_assign_print=True, materials=materials, selected_materials=selected_materials %}{% include 'fragments/list_spools.html' %}{% endwith %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- add material filtering support to the print spool selection view
- preselect material filter based on the print's filament usage
- pass material filter state to the spool list fragment when assigning prints

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692950820010832985bf0dad229e32d1)