### PR TITLE
Lower AMS humidity droplet number placement

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -278,3 +278,48 @@ main.container {
         width: 100%;
     }
 }
+
+/* AMS humidity visualization */
+.ams-humidity-display {
+    gap: 0.35rem !important;
+}
+
+.humidity-droplet-wrapper {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+}
+
+.humidity-droplet {
+    width: 28px;
+    height: 28px;
+}
+
+.droplet-base {
+    fill: transparent;
+}
+
+.droplet-fill {
+    fill: var(--bs-info, #0dcaf0);
+    opacity: 0.8;
+}
+
+.droplet-outline {
+    fill: none;
+    stroke: #000;
+    stroke-width: 0.8;
+}
+
+.humidity-level-number {
+    position: absolute;
+    font-weight: 700;
+    font-size: 0.85rem;
+    color: var(--bs-body-color);
+    line-height: 1;
+    left: 50%;
+    top: 60%;
+    transform: translate(-50%, -50%);
+}

--- a/templates/fragments/ams_metrics.html
+++ b/templates/fragments/ams_metrics.html
@@ -4,24 +4,26 @@
     {% set humidity_level = [humidity_level, 1]|max %}
     {% set fill_pct = humidity_level * 20 %}
     {% set clip_id = 'humidity-clip-' ~ ams.id %}
+    {% set show_raw = ams.humidity_raw is defined and ams.humidity_raw|int != 0 %}
     <span class="text-muted small d-flex align-items-center gap-2">
       <span class="d-flex align-items-center gap-1 ams-humidity-display">
         <span class="text-body-secondary">Humidity</span>
-        <span class="humidity-droplet-wrapper">
-          <svg class="humidity-droplet" viewBox="-0.5 -0.5 17 17" aria-hidden="true" focusable="false">
-            <defs>
-              <clipPath id="{{ clip_id }}">
-                <path d="M8 16a6 6 0 0 0 6-6c0-1.655-1.122-2.904-2.432-4.362C10.254 4.176 8.75 2.503 8 0c0 0-6 5.686-6 10a6 6 0 0 0 6 6M6.646 4.646l.708.708c-.29.29-1.128 1.311-1.907 2.87l-.894-.448c.82-1.641 1.717-2.753 2.093-3.13" />
-              </clipPath>
-            </defs>
-            <rect width="100%" height="100%" class="droplet-base" clip-path="url(#{{ clip_id }})" />
-            <rect width="100%" height="{{ fill_pct }}%" y="{{ 100 - fill_pct }}%" class="droplet-fill" clip-path="url(#{{ clip_id }})" />
-            <path class="droplet-outline" d="M8 16a6 6 0 0 0 6-6c0-1.655-1.122-2.904-2.432-4.362C10.254 4.176 8.75 2.503 8 0c0 0-6 5.686-6 10a6 6 0 0 0 6 6" />
-          </svg>
-          <span class="humidity-level-number">{{ humidity_level }}</span>
-        </span>
-        {% if ams.humidity_raw is defined %}
+        {% if show_raw %}
           <span class="fw-semibold">{{ ams.humidity_raw }}%</span>
+        {% else %}
+          <span class="humidity-droplet-wrapper">
+            <svg class="humidity-droplet" viewBox="-0.5 -0.5 17 17" aria-hidden="true" focusable="false">
+              <defs>
+                <clipPath id="{{ clip_id }}">
+                  <path d="M8 16a6 6 0 0 0 6-6c0-1.655-1.122-2.904-2.432-4.362C10.254 4.176 8.75 2.503 8 0c0 0-6 5.686-6 10a6 6 0 0 0 6 6M6.646 4.646l.708.708c-.29.29-1.128 1.311-1.907 2.87l-.894-.448c.82-1.641 1.717-2.753 2.093-3.13" />
+                </clipPath>
+              </defs>
+              <rect width="100%" height="100%" class="droplet-base" clip-path="url(#{{ clip_id }})" />
+              <rect width="100%" height="{{ fill_pct }}%" y="{{ 100 - fill_pct }}%" class="droplet-fill" clip-path="url(#{{ clip_id }})" />
+              <path class="droplet-outline" d="M8 16a6 6 0 0 0 6-6c0-1.655-1.122-2.904-2.432-4.362C10.254 4.176 8.75 2.503 8 0c0 0-6 5.686-6 10a6 6 0 0 0 6 6" />
+            </svg>
+            <span class="humidity-level-number">{{ humidity_level }}</span>
+          </span>
         {% endif %}
       </span>
       <span>Temp: {{ ams.temp }}°C</span>

--- a/templates/fragments/ams_metrics.html
+++ b/templates/fragments/ams_metrics.html
@@ -1,0 +1,30 @@
+{% macro humidity_display(ams) %}
+  {% if ams.temp != "0.0" %}
+    {% set humidity_level = [ams.humidity|int, 5]|min %}
+    {% set humidity_level = [humidity_level, 1]|max %}
+    {% set fill_pct = humidity_level * 20 %}
+    {% set clip_id = 'humidity-clip-' ~ ams.id %}
+    <span class="text-muted small d-flex align-items-center gap-2">
+      <span class="d-flex align-items-center gap-1 ams-humidity-display">
+        <span class="text-body-secondary">Humidity</span>
+        <span class="humidity-droplet-wrapper">
+          <svg class="humidity-droplet" viewBox="-0.5 -0.5 17 17" aria-hidden="true" focusable="false">
+            <defs>
+              <clipPath id="{{ clip_id }}">
+                <path d="M8 16a6 6 0 0 0 6-6c0-1.655-1.122-2.904-2.432-4.362C10.254 4.176 8.75 2.503 8 0c0 0-6 5.686-6 10a6 6 0 0 0 6 6M6.646 4.646l.708.708c-.29.29-1.128 1.311-1.907 2.87l-.894-.448c.82-1.641 1.717-2.753 2.093-3.13" />
+              </clipPath>
+            </defs>
+            <rect width="100%" height="100%" class="droplet-base" clip-path="url(#{{ clip_id }})" />
+            <rect width="100%" height="{{ fill_pct }}%" y="{{ 100 - fill_pct }}%" class="droplet-fill" clip-path="url(#{{ clip_id }})" />
+            <path class="droplet-outline" d="M8 16a6 6 0 0 0 6-6c0-1.655-1.122-2.904-2.432-4.362C10.254 4.176 8.75 2.503 8 0c0 0-6 5.686-6 10a6 6 0 0 0 6 6" />
+          </svg>
+          <span class="humidity-level-number">{{ humidity_level }}</span>
+        </span>
+        {% if ams.humidity_raw is defined %}
+          <span class="fw-semibold">{{ ams.humidity_raw }}%</span>
+        {% endif %}
+      </span>
+      <span>Temp: {{ ams.temp }}°C</span>
+    </span>
+  {% endif %}
+{% endmacro %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
 
+{% from 'fragments/ams_metrics.html' import humidity_display %}
+
 {% block content %}
 <!-- AMS and External Spool Row -->
 <div class="row">
@@ -16,9 +18,7 @@
     <div class="card shadow-sm">
       <div class="card-header d-flex justify-content-between align-items-center">
         <h5 class="mb-0">AMS{% if ams_data|length > 1 %} {{ ams.id|int +1 }} {% endif %}</h5>
-        {% if ams.temp != "0.0" %}
-        <span class="text-muted small">Humidity: {{ ams.humidity }}%, Temp: {{ ams.temp }}°C</span>
-        {% endif %}
+        {{ humidity_display(ams) }}
       </div>
       <div class="card-body">
         <div class="row">

--- a/templates/spool_info.html
+++ b/templates/spool_info.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
 
+{% from 'fragments/ams_metrics.html' import humidity_display %}
+
 {% block content %}
 {% include 'fragments/spool_details.html' %}
 
@@ -15,9 +17,7 @@
     <div class="card shadow-sm">
       <div class="card-header d-flex justify-content-between align-items-center">
         <h5 class="mb-0">AMS{% if ams_data|length > 1 %} {{ ams.id|int +1 }} {% endif %}</h5>
-                {% if ams.temp != "0.0" %}
-        <span class="text-muted small">Humidity: {{ ams.humidity }}%, Temp: {{ ams.temp }}°C</span>
-                {% endif %}
+        {{ humidity_display(ams) }}
       </div>
       <div class="card-body">
         <div class="row">


### PR DESCRIPTION
## Summary
- reposition the AMS humidity level number lower within the droplet to better match the visual belly placement

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a925cb780832989baaf0718b3cec0)